### PR TITLE
fix typo when doing the backup prodinfo

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -96,7 +96,7 @@ public:
 		{
 			for (int i = 0; i < 99; i++)
 			{
-				sprintf(filename, "proinfo.bin.%d", i);
+				sprintf(filename, "prodinfo.bin.%d", i);
 
 				if (!fileExists(filename))
 				{


### PR DESCRIPTION
this would remove a future headache when someone doesn't bother to read the filename before attempting to restore their profindo